### PR TITLE
Use ::RSpec.configuration.backtrace_exclusion_patterns instead of backtrace_clean_patterns when available

### DIFF
--- a/lib/rr/integrations/rspec_2.rb
+++ b/lib/rr/integrations/rspec_2.rb
@@ -15,10 +15,10 @@ module RR
         ::RSpec.configure do |config|
           config.mock_with Mixin
           config.include RR::Adapters::RRMethods
-        end
-        patterns = ::RSpec.configuration.backtrace_clean_patterns
-        unless patterns.include?(RR::Errors::BACKTRACE_IDENTIFIER)
-          patterns.push(RR::Errors::BACKTRACE_IDENTIFIER)
+          patterns = config.respond_to?(:backtrace_exclusion_patterns) ? config.backtrace_exclusion_patterns : config.backtrace_clean_patterns
+          unless patterns.include?(RR::Errors::BACKTRACE_IDENTIFIER)
+            patterns.push(RR::Errors::BACKTRACE_IDENTIFIER)
+          end
         end
       end
     end


### PR DESCRIPTION
`::RSpec.configuration.backtrace_clean_patterns` has been deprecated since 2.14 and was renamed to `backtrace_exclusion_patterns` in 3.0

see: https://github.com/rspec/rspec-core/commit/b4be678
