### PR TITLE
Fix minitest version on minitest 4

### DIFF
--- a/lib/rr/integrations/minitest.rb
+++ b/lib/rr/integrations/minitest.rb
@@ -20,7 +20,7 @@ module RR
       end
 
       def version_constant
-        ::Minitest::VERSION
+        ::Minitest::Unit::VERSION
       end
     end
 


### PR DESCRIPTION
Minitest 4.x dont have `Minitest::VERSION` constant. see https://github.com/seattlerb/minitest/blob/644a52fd0aa0205c8767829ca8afbd8c158f9ff2/lib/minitest/unit.rb#L733-L734

This change should work for minitest 5 too, https://github.com/seattlerb/minitest/blob/master/lib/minitest/unit.rb#L22.

Without this I am getting this error:
https://gist.github.com/arthurnn/3135d31489a07a8d4371