### PR TITLE
Add Ruby 2.4.0 tests on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ notifications:
     recipients:
       - rr@ml.commit-email.info
 language: ruby
-script: rake ${TARGET}
+before_install:
+  - gem update bundler
+script: bundle exec rake ${TARGET}
 matrix:
   include:
   - rvm: 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,7 @@ matrix:
   - rvm: 2.3.1
     env:
     - TARGET="test"
+  - rvm: 2.4.0
+    env:
+    - TARGET="test"
 #  allow_failures:


### PR DESCRIPTION
Hello,
Is it possible to add Ruby 2.4.0 to Travis?
I checked it on my local environment.

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
```

```
bundle install --path vendor/bundle
```

```
$ bundle exec rake test
/usr/local/ruby-2.4.0/bin/ruby test/run-test.rb
Loaded suite test
Started
....

Finished in 0.003924345 seconds.
-------------------------------------------------------------------------------------
4 tests, 5 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------
1019.28 tests/s, 1274.10 assertions/s
```


