### PR TITLE
Add ruby-head as allow_failures in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,11 @@ matrix:
   - rvm: 2.4.0
     env:
     - TARGET="test"
-#  allow_failures:
+  - rvm: ruby-head
+    env:
+    - TARGET="test"
+  allow_failures:
+  - rvm: ruby-head
+    env:
+    - TARGET="test"
+  fast_finish: true


### PR DESCRIPTION
I want to add `ruby-head` as allow_failures in `.travis.yml`.
I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
I think that is the reason why `rails` and `rspec` can support new version Ruby as faster.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to add it?

Thanks.