### PR TITLE
Add Ruby 2.7 to Travis-CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ matrix:
   - rvm: 2.4.0
     env:
     - TARGET="test"
+  - rvm: 2.7.0
+    env:
+    - TARGET="test"
   - rvm: ruby-head
     env:
     - TARGET="test"


### PR DESCRIPTION
Ruby 2.7 got released some time ago. The first distributions start to
ship to. We should ensure that this project works on 2. as well, so I
added it to the test matrix.