### PR TITLE
Improve kwargs support for Ruby 2.7

### DIFF
--- a/lib/rr/double_definitions/strategies/strategy.rb
+++ b/lib/rr/double_definitions/strategies/strategy.rb
@@ -36,6 +36,8 @@ module RR
           def permissive_argument
             if args.empty? and kwargs.empty?
               definition.with_any_args
+            elsif kwargs.empty?
+              definition.with(*args)
             else
               definition.with(*args, **kwargs)
             end

--- a/lib/rr/injections/double_injection.rb
+++ b/lib/rr/injections/double_injection.rb
@@ -137,7 +137,7 @@ module RR
         id = BoundObjects.size
         BoundObjects[id] = subject_class
 
-        if KeywordArguments.fully_supported?
+        if KeywordArguments.fully_supported? && KeywordArguments.accept_kwargs?(subject_class, method_name)
           subject_class.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
             def #{method_name}(*args, **kwargs, &block)
               ::RR::Injections::DoubleInjection::BoundObjects[#{id}].class_eval do
@@ -163,7 +163,7 @@ module RR
         id = BoundObjects.size
         BoundObjects[id] = subject_class
 
-        if KeywordArguments.fully_supported?
+        if KeywordArguments.fully_supported? && KeywordArguments.accept_kwargs?(subject_class, method_name)
           subject_class.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
             def #{method_name}(*args, **kwargs, &block)
               arguments = MethodArguments.new(args, kwargs, block)

--- a/lib/rr/keyword_arguments.rb
+++ b/lib/rr/keyword_arguments.rb
@@ -10,6 +10,12 @@ module RR
           false
         end
       end
+
+      def accept_kwargs?(subject_class, method_name)
+        subject_class.instance_method(method_name).parameters.any? { |t, _| t == :key || t == :keyrest }
+      rescue NameError
+        true
+      end
     end
   end
 end

--- a/lib/rr/method_dispatches/method_dispatch.rb
+++ b/lib/rr/method_dispatches/method_dispatch.rb
@@ -31,7 +31,7 @@ module RR
 
       def call_original_method
         if subject_has_original_method?
-          if KeywordArguments.fully_supported?
+          if KeywordArguments.fully_supported? && !kwargs.empty?
             subject.__send__(original_method_alias_name, *args, **kwargs, &block)
           else
             subject.__send__(original_method_alias_name, *args, &block)
@@ -53,7 +53,7 @@ module RR
           call_original_method
         else
           if implementation
-            if KeywordArguments.fully_supported?
+            if KeywordArguments.fully_supported? && kwargs.empty?
               implementation.call(*args, **kwargs, &block)
             else
               implementation.call(*args, &block)

--- a/lib/rr/method_dispatches/method_missing_dispatch.rb
+++ b/lib/rr/method_dispatches/method_missing_dispatch.rb
@@ -52,7 +52,7 @@ module RR
           if double_injection = Injections::DoubleInjection.find(subject_class, method_name)
             double_injection.bind_method
             # The DoubleInjection takes care of calling double.method_call
-            if KeywordArguments.fully_supported?
+            if KeywordArguments.fully_supported? && !kwargs.empty?
               subject.__send__(method_name, *args, **kwargs, &block)
             else
               subject.__send__(method_name, *args, &block)

--- a/test/mock/test_proxy_kwargs.rb
+++ b/test/mock/test_proxy_kwargs.rb
@@ -1,0 +1,51 @@
+class TestMockProxyKwargs < Test::Unit::TestCase
+  class C
+    def m1(a, b)
+      [a, b]
+    end
+
+    def m2(a, **b)
+      [a, b]
+    end
+
+    def m3(*a)
+      [a]
+    end
+
+    def m4(*a, **b)
+      [a, b]
+    end
+
+    def m5(a, *b)
+      [a, b]
+    end
+
+    def m6(*a, b)
+      [a, b]
+    end
+  end
+
+  setup do
+    @obj1 = C.new
+    @obj2 = C.new
+  end
+
+  prefix = { req: '', rest: '*', keyrest: '**' }
+  %i[m1 m2 m3 m4 m5 m6].each do |method|
+    sig = C.instance_method(method).parameters
+      .map { |t, n| "#{prefix[t]}#{n}" }
+      .join(', ')
+    data(:args, ['1, a: 2', '1, { a: 2 }', '1, **{ a: 2 }'])
+    test "#{method}(#{sig})" do
+      eval("proxy.mock(@obj2).#{method}.with_any_args", binding, __FILE__, __LINE__)
+
+      val1, val2 = %w[obj1 obj2].map do |var|
+        eval("@#{var}.#{method}(#{data[:args]})", binding, __FILE__, __LINE__)
+      rescue => e
+        { class: e.class, message: e.message }
+      end
+
+      assert_equal(val1, val2)
+    end
+  end
+end


### PR DESCRIPTION
On Ruby 2.7, `proxy.{stub,mock}` may cause warning when that is called with kwargs or with hash as the last arg.

Before this PR:

```
Loaded suite test
Started
mock: 
  TestMockProxyKwargs: 
    test: m1(a, b)[args: "1, a: 2"]:			.: (0.000784)
    test: m1(a, b)[args: "1, { a: 2 }"]:		/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/lib/rr/injections/double_injection.rb:168: warning: The called method `m1' is defined here
.: (0.000422)
    test: m1(a, b)[args: "1, **{ a: 2 }"]:		.: (0.000368)
    test: m2(a, **b)[args: "1, a: 2"]:			.: (0.000347)
    test: m2(a, **b)[args: "1, { a: 2 }"]:		/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/test/mock/test_proxy_kwargs.rb:7: warning: The called method `m2' is defined here
/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/lib/rr/injections/double_injection.rb:168: warning: The called method `m2' is defined here
.: (0.000358)
    test: m2(a, **b)[args: "1, **{ a: 2 }"]:		.: (0.000346)
    test: m3(*a)[args: "1, a: 2"]:			.: (0.000369)
    test: m3(*a)[args: "1, { a: 2 }"]:			/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/lib/rr/injections/double_injection.rb:168: warning: The called method `m3' is defined here
.: (0.000350)
    test: m3(*a)[args: "1, **{ a: 2 }"]:		.: (0.000354)
    test: m4(*a, **b)[args: "1, a: 2"]:			.: (0.000349)
    test: m4(*a, **b)[args: "1, { a: 2 }"]:		/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/test/mock/test_proxy_kwargs.rb:15: warning: The called method `m4' is defined here
/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/lib/rr/injections/double_injection.rb:168: warning: The called method `m4' is defined here
.: (0.000350)
    test: m4(*a, **b)[args: "1, **{ a: 2 }"]:		.: (0.000333)
    test: m5(a, *b)[args: "1, a: 2"]:			.: (0.000343)
    test: m5(a, *b)[args: "1, { a: 2 }"]:		/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/lib/rr/injections/double_injection.rb:168: warning: The called method `m5' is defined here
.: (0.000362)
    test: m5(a, *b)[args: "1, **{ a: 2 }"]:		.: (0.000349)
    test: m6(*a, b)[args: "1, a: 2"]:			.: (0.000355)
    test: m6(*a, b)[args: "1, { a: 2 }"]:		/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/lib/rr/injections/double_injection.rb:168: warning: The called method `m6' is defined here
.: (0.000397)
    test: m6(*a, b)[args: "1, **{ a: 2 }"]:		.: (0.001132)
```

I think warnings on `m1` `m3` `m5` `m6` are unexpected.

After this PR:

```
Loaded suite test
Started
mock: 
  TestMockProxyKwargs: 
    test: m1(a, b)[args: "1, a: 2"]:			.: (0.000675)
    test: m1(a, b)[args: "1, { a: 2 }"]:		.: (0.000359)
    test: m1(a, b)[args: "1, **{ a: 2 }"]:		.: (0.000356)
    test: m2(a, **b)[args: "1, a: 2"]:			.: (0.000347)
    test: m2(a, **b)[args: "1, { a: 2 }"]:		/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/test/mock/test_proxy_kwargs.rb:7: warning: The called method `m2' is defined here
/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/lib/rr/injections/double_injection.rb:168: warning: The called method `m2' is defined here
.: (0.000360)
    test: m2(a, **b)[args: "1, **{ a: 2 }"]:		.: (0.000343)
    test: m3(*a)[args: "1, a: 2"]:			.: (0.000352)
    test: m3(*a)[args: "1, { a: 2 }"]:			.: (0.000349)
    test: m3(*a)[args: "1, **{ a: 2 }"]:		.: (0.000359)
    test: m4(*a, **b)[args: "1, a: 2"]:			.: (0.000337)
    test: m4(*a, **b)[args: "1, { a: 2 }"]:		/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/test/mock/test_proxy_kwargs.rb:15: warning: The called method `m4' is defined here
/.../rr/test/mock/test_proxy_kwargs.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../rr/lib/rr/injections/double_injection.rb:168: warning: The called method `m4' is defined here
.: (0.000353)
    test: m4(*a, **b)[args: "1, **{ a: 2 }"]:		.: (0.000336)
    test: m5(a, *b)[args: "1, a: 2"]:			.: (0.000347)
    test: m5(a, *b)[args: "1, { a: 2 }"]:		.: (0.000345)
    test: m5(a, *b)[args: "1, **{ a: 2 }"]:		.: (0.000337)
    test: m6(*a, b)[args: "1, a: 2"]:			.: (0.000356)
    test: m6(*a, b)[args: "1, { a: 2 }"]:		.: (0.000362)
    test: m6(*a, b)[args: "1, **{ a: 2 }"]:		.: (0.001085)
```