### PR TITLE
Improve Ruby 2.7 keyword argument support

### DIFF
--- a/lib/rr/double_definitions/double_definition_create_blank_slate.rb
+++ b/lib/rr/double_definitions/double_definition_create_blank_slate.rb
@@ -22,6 +22,7 @@ module RR
         def method_missing(method_name, *args, &block)
           @double_definition_create.call(method_name, args, {}, &block)
         end
+        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
       end
 
       def __double_definition_create__

--- a/lib/rr/double_definitions/strategies/strategy.rb
+++ b/lib/rr/double_definitions/strategies/strategy.rb
@@ -36,8 +36,6 @@ module RR
           def permissive_argument
             if args.empty? and kwargs.empty?
               definition.with_any_args
-            elsif kwargs.empty?
-              definition.with(*args)
             else
               definition.with(*args, **kwargs)
             end

--- a/lib/rr/injections/double_injection.rb
+++ b/lib/rr/injections/double_injection.rb
@@ -144,6 +144,7 @@ module RR
             end
             method_missing(:#{method_name}, *args, &block)
           end
+          ruby2_keywords(:#{method_name}) if respond_to?(:ruby2_keywords, true)
         RUBY
         self
       end
@@ -181,6 +182,7 @@ module RR
                 arguments.block
               )
             end
+            ruby2_keywords(:#{method_name}) if respond_to?(:ruby2_keywords, true)
           RUBY
         end
         self

--- a/lib/rr/injections/double_injection.rb
+++ b/lib/rr/injections/double_injection.rb
@@ -137,25 +137,14 @@ module RR
         id = BoundObjects.size
         BoundObjects[id] = subject_class
 
-        if KeywordArguments.fully_supported? && KeywordArguments.accept_kwargs?(subject_class, method_name)
-          subject_class.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-            def #{method_name}(*args, **kwargs, &block)
-              ::RR::Injections::DoubleInjection::BoundObjects[#{id}].class_eval do
-                remove_method(:#{method_name})
-              end
-              method_missing(:#{method_name}, *args, **kwargs, &block)
+        subject_class.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+          def #{method_name}(*args, &block)
+            ::RR::Injections::DoubleInjection::BoundObjects[#{id}].class_eval do
+              remove_method(:#{method_name})
             end
-          RUBY
-        else
-          subject_class.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-            def #{method_name}(*args, &block)
-              ::RR::Injections::DoubleInjection::BoundObjects[#{id}].class_eval do
-                remove_method(:#{method_name})
-              end
-              method_missing(:#{method_name}, *args, &block)
-            end
-          RUBY
-        end
+            method_missing(:#{method_name}, *args, &block)
+          end
+        RUBY
         self
       end
 
@@ -163,7 +152,7 @@ module RR
         id = BoundObjects.size
         BoundObjects[id] = subject_class
 
-        if KeywordArguments.fully_supported? && KeywordArguments.accept_kwargs?(subject_class, method_name)
+        if KeywordArguments.fully_supported?
           subject_class.class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
             def #{method_name}(*args, **kwargs, &block)
               arguments = MethodArguments.new(args, kwargs, block)

--- a/lib/rr/injections/method_missing_injection.rb
+++ b/lib/rr/injections/method_missing_injection.rb
@@ -106,6 +106,7 @@ module RR
                 ).call
               end
             end
+            ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
           METHOD
         end
       end

--- a/lib/rr/keyword_arguments.rb
+++ b/lib/rr/keyword_arguments.rb
@@ -1,7 +1,7 @@
 module RR
   module KeywordArguments
     class << self
-      if (RUBY_VERSION <=> "2.7.0") >= 0
+      if (RUBY_VERSION <=> "3.0.0") >= 0
         def fully_supported?
           true
         end
@@ -9,12 +9,6 @@ module RR
         def fully_supported?
           false
         end
-      end
-
-      def accept_kwargs?(subject_class, method_name)
-        subject_class.instance_method(method_name).parameters.any? { |t, _| t == :key || t == :keyrest }
-      rescue NameError
-        true
       end
     end
   end

--- a/lib/rr/method_dispatches/method_dispatch.rb
+++ b/lib/rr/method_dispatches/method_dispatch.rb
@@ -31,7 +31,7 @@ module RR
 
       def call_original_method
         if subject_has_original_method?
-          if KeywordArguments.fully_supported? && !kwargs.empty?
+          if KeywordArguments.fully_supported?
             subject.__send__(original_method_alias_name, *args, **kwargs, &block)
           else
             subject.__send__(original_method_alias_name, *args, &block)
@@ -53,7 +53,7 @@ module RR
           call_original_method
         else
           if implementation
-            if KeywordArguments.fully_supported? && !kwargs.empty?
+            if KeywordArguments.fully_supported?
               implementation.call(*args, **kwargs, &block)
             else
               implementation.call(*args, &block)

--- a/lib/rr/method_dispatches/method_missing_dispatch.rb
+++ b/lib/rr/method_dispatches/method_missing_dispatch.rb
@@ -52,7 +52,7 @@ module RR
           if double_injection = Injections::DoubleInjection.find(subject_class, method_name)
             double_injection.bind_method
             # The DoubleInjection takes care of calling double.method_call
-            if KeywordArguments.fully_supported? && !kwargs.empty?
+            if KeywordArguments.fully_supported?
               subject.__send__(method_name, *args, **kwargs, &block)
             else
               subject.__send__(method_name, *args, &block)

--- a/lib/rr/space.rb
+++ b/lib/rr/space.rb
@@ -22,6 +22,7 @@ module RR
         def method_missing(method_name, *args, &block)
           instance.__send__(method_name, *args, &block)
         end
+        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
       end
     end
 

--- a/test/mock/test_proxy_kwargs.rb
+++ b/test/mock/test_proxy_kwargs.rb
@@ -33,8 +33,7 @@ class TestMockProxyKwargs < Test::Unit::TestCase
     obj1 = klass.new
     obj2 = klass.new
     proxy.mock(obj2).call.with_any_args
-    case data[:style]
-    when :hash
+    if data[:style] == :hash && RR::KeywordArguments.fully_supported?
       assert_raise(ArgumentError) do
         obj1.call(1, {a: 2})
       end

--- a/test/test_stub.rb
+++ b/test/test_stub.rb
@@ -4,4 +4,19 @@ class TestStub < Test::Unit::TestCase
     stub(object).hello("Alice", "Bob", comment: "Wow!").once
     object.hello("Alice", "Bob", comment: "Wow!")
   end
+
+  test "keyword arguments expectation" do
+    object = Object.new
+    stub(object).call(1, b: 2).once
+    object.call(1, b: 2)
+  end
+
+  test "keyword arguments expectation with implementation" do
+    klass = Class.new do
+      def call(a, b:); end
+    end
+    object = klass.new
+    stub(object).call(1, b: 2).once
+    object.call(1, b: 2)
+  end
 end


### PR DESCRIPTION
On 3.0.4, test script of #81 failes.

```
Failure: test: proxy.mock(Test81):
  On subject #<TestClass81:0x00007ff71a046ff0>,
  unexpected method invocation:
    x(1, {:b=>2})
  expected invocations:
  - x(1, b: 2)
/.../rr/test/test_81.rb:12:in `block in <class:Test81>'
      9: 
     10:   test 'proxy.mock' do
     11:     proxy.mock(@foo).x(1, b: 2)
  => 12:     @foo.x(1, b: 2)
     13:   end
     14: 
     15:   test 'mock' do
```

This PR fixes this problem.