### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
           - "head"
           - "truffleruby-head"
     steps:

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -13,6 +13,7 @@ when "minitest"
   require "minitest"
   require "rr"
 when "minitest-active-support"
+  require "active_support"
   require "active_support/test_case"
   require "rr"
 end


### PR DESCRIPTION
In addition to adding 3.1 to the list of tested Rubies, this PR fixes a class loading issue in the integration tests.  This class loading issue appeared because ActiveSupport 7.0 is now being pulled in for these specs.