### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,11 @@ jobs:
           - "head"
           - "truffleruby-head"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby-version }}"
           bundler-cache: true
-      - run: bundle install
       - run: bundle exec rake test
 
   integration:
@@ -39,10 +38,9 @@ jobs:
     env:
       RR_INTEGRATION: "${{ matrix.integration }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.0"
           bundler-cache: true
-      - run: bundle install
       - run: bundle exec rake test


### PR DESCRIPTION
This PR is a follow-up to rr/rr#90.
- Remove redundant `bundle install`
  - `bundler-cache` runs `bundle install`.
    I forgot to remove these codes in #90.  :bow:
- Use `actions/checkout` version 3
  https://github.com/actions/checkout/releases/tag/v3.0.0