### PR TITLE
HTTPS links and updated text on ruby versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,9 +47,9 @@
   framework of choice, whether RSpec, Test::Unit or MiniTest/MiniSpec.
   RR is tested against all active Ruby versions.</p>
 
-  <p>RR was created by <a href="https://github.com/btakita">Brian Takita</a> and
-  is currently maintained by <a href="https://github.com/mcmire">Elliot
-  Winkler</a>.</p>
+  <p>RR was created by <a href="https://github.com/btakita">Brian Takita</a>.
+  Previously maintained by <a href="https://github.com/mcmire">Elliot Winkler</a>
+  and currently by <a href="https://github.com/kou">Kouhei Sutou</a>.</p>
 </section>
 
 <section>

--- a/index.html
+++ b/index.html
@@ -6,16 +6,16 @@
 <head>
   <title>RR - a test double framework for Ruby</title>
   <link rel="stylesheet" href="layout.css" type='text/css' />
-  <link href='http://fonts.googleapis.com/css?family=Oxygen:400,700' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Lato:900,400italic' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Oswald:300,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Oxygen:400,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Lato:900,400italic' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Oswald:300,700' rel='stylesheet' type='text/css'>
 </head>
 
 <body>
 
 <header>
   <div class="name">
-    <h1><a href="http://github.com/rr/rr#readme">rr</a></h1>
+    <h1><a href="https://github.com/rr/rr#readme">rr</a></h1>
     <div><span>a test double framework for Ruby with a succinct syntax</span></div>
   </div>
 </header>
@@ -44,12 +44,11 @@
   you want to define test doubles.</p>
 
   <p>Finally, RR provides adapters so you can integrate it with your test
-  framework of choice, whether RSpec, Test::Unit or MiniTest/MiniSpec. In
-  addition, RR is constantly tested against Ruby 1.9 and 2.0 as well as Rubinius
-  and JRuby.</p>
+  framework of choice, whether RSpec, Test::Unit or MiniTest/MiniSpec.
+  RR is tested against all active Ruby versions.</p>
 
-  <p>RR was created by <a href="http://github.com/btakita">Brian Takita</a> and
-  is currently maintained by <a href="http://github.com/mcmire">Elliot
+  <p>RR was created by <a href="https://github.com/btakita">Brian Takita</a> and
+  is currently maintained by <a href="https://github.com/mcmire">Elliot
   Winkler</a>.</p>
 </section>
 
@@ -130,7 +129,7 @@
 </section>
 
 <footer>
-  Design inspired by <a href="http://defunkt.io/hub">hub</a>.
+  Design inspired by <a href="https://hub.github.com">hub</a>.
 </footer>
 
 </body>


### PR DESCRIPTION
* Use HTTPS for all links
* Fix broken hub link
* Don't mention Ruby 1.9 and 2.0, instead just say 'active ruby versions'.