### PR TITLE
Fix case/when indentation

### DIFF
--- a/lib/rr/method_dispatches/base_method_dispatch.rb
+++ b/lib/rr/method_dispatches/base_method_dispatch.rb
@@ -74,12 +74,12 @@ module RR
 
       def extract_subject_from_return_value(return_value)
         case return_value
-          when DoubleDefinitions::DoubleDefinition
-            return_value.root_subject
-          when DoubleDefinitions::DoubleDefinitionCreateBlankSlate
-            return_value.__double_definition_create__.root_subject
-          else
-            return_value
+        when DoubleDefinitions::DoubleDefinition
+          return_value.root_subject
+        when DoubleDefinitions::DoubleDefinitionCreateBlankSlate
+          return_value.__double_definition_create__.root_subject
+        else
+          return_value
         end
       end
 


### PR DESCRIPTION
When running with VERBOSE, this warns. This was found through running the test suite of the debug gem.