### PR TITLE
Increment test assertions count

### DIFF
--- a/lib/rr/integrations/minitest_4.rb
+++ b/lib/rr/integrations/minitest_4.rb
@@ -3,6 +3,7 @@ module RR
     class MiniTest4
       module Mixin
         def assert_received(subject, &block)
+          self.assertions += 1
           block.call(received(subject)).call
         end
       end
@@ -77,4 +78,3 @@ module RR
     RR.register_adapter MiniTest4
   end
 end
-

--- a/test/integration/test_minitest.rb
+++ b/test/integration/test_minitest.rb
@@ -1,4 +1,4 @@
-class TestIntegerationMinitest < Test::Unit::TestCase
+class TestIntegrationMinitest < Test::Unit::TestCase
   setup do
     omit("Require Minitest") unless defined?(::Minitest)
     omit("Require not Active Support") if defined?(::ActiveSupport::TestCase)
@@ -19,5 +19,21 @@ hello("Alice")
 Called 0 times.
 Expected 1 times.
     MESSAGE
+  end
+
+  test("assert_received increments assertions count") do
+    test_class = Class.new(Minitest::Test) do
+      def test_assert_received
+        object = Object.new
+        stub(object).hello { "Hello!" }
+        object.hello
+        assert_received(object) do |expect|
+          expect.hello
+        end
+      end
+    end
+
+    result = test_class.new(:test_assert_received).run
+    assert_equal(1, result.assertions)
   end
 end


### PR DESCRIPTION
This PR updates Minitest assertion counts when using `assert_received`, aligning with a recent update in Rails 7.2. From Rails 7.2, tests without assertions emit warnings like "Test is missing assertions". This update no longer triggers Rails' warnings.